### PR TITLE
fix(utime for archive):  Set utime for the zip itself to help idempotency

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,6 +157,7 @@ async function repackFunctions(archives) {
 
     // Copy the repacked zip file to the .serverless directory.
     fs.copyFileSync(`${repackDir}/${funcName}.zip.new`, zips[index]);
+    fs.utimesSync(zips[index], time, time)
   }
 
   // Remove the .repack directory


### PR DESCRIPTION
## Purpose

This seems to only be an issue on linux, not Mac.  But I need to keep the utime of the package contents as well as the package itself consistent.

#### Linked Issues to Close

None

## Approach

See code.

## Learning

_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Assorted Notes/Considerations

_List any other information that you think is important... a post-merge activity, someone to notify, etc._

#### Pull Request Creator Checklist

- [ ] Any associated issue(s) are linked above.
- [ ] This PR and linked issues(s) are a complete description of the changeset.
- [ ] Someone has been assigned this PR.
- [ ] Someone has been marked as reviewer on this PR.

#### Pull Request Assignee Checklist

- [ ] Any associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for any linked issues.
- [ ] This PR and linked issues(s) are a complete description of the changeset.
